### PR TITLE
Initial support for SPI and I2C

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.4.0"
 authors = [
 	"Jorge Aparicio <jorge@japaric.io>",
 	"Jonathan 'theJPster' Pallant <github@thejpster.org.uk>",
+	"Marc Poulhiès <dkm@kataplop.net>",
 ]
 description = "HAL for the TM4C123x family of microcontrollers"
 keywords = ["arm", "cortex-m", "tm4c", "lm4f120", "hal"]

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,5 +1,6 @@
 Copyright (c) 2017-2018 Jonathan 'theJPster' Pallant
 Copyright (c) 2017-2018 Jorge Aparicio
+Copyright (c) 2018 Marc Poulhiès
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -236,14 +236,6 @@ impl AlternateFunctionChoice for AF14 {
     }
 }
 
-/// Alternate function 15 (type state)
-pub struct AF15;
-impl AlternateFunctionChoice for AF15 {
-    fn number() -> u32 {
-        return 15;
-    }
-}
-
 /// Pin is locked through the GPIOCR register
 pub struct Locked;
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,0 +1,343 @@
+//! Inter-Integrated Circuit (I2C) bus
+
+use tm4c123x::{I2C0, I2C1, I2C2, I2C3};
+
+use gpio::gpioa::{PA6, PA7};
+use gpio::gpiob::{PB2, PB3};
+use gpio::gpioe::{PE4, PE5};
+use gpio::gpiod::{PD0, PD1};
+
+use gpio::{AF3, AlternateFunction, Floating, OpenDrain, OutputMode};
+
+use sysctl::Clocks;
+use sysctl;
+
+use hal::blocking::i2c::{Write, WriteRead, Read};
+use time::Hertz;
+
+/// I2C error
+#[derive(Debug)]
+pub enum Error {
+    /// Bus error
+    Bus,
+    /// Arbitration loss
+    Arbitration,
+
+    /// Missing Data ACK
+    DataAck,
+
+    /// Missing Addrees ACK
+    AdrAck,
+
+    #[doc(hidden)] _Extensible,
+}
+
+// FIXME these should be "closed" traits
+/// SCL pin -- DO NOT IMPLEMENT THIS TRAIT
+pub unsafe trait SclPin<I2C> {}
+
+/// SDA pin -- DO NOT IMPLEMENT THIS TRAIT
+pub unsafe trait SdaPin<I2C> {}
+
+unsafe impl<T> SclPin<I2C0> for PB2<AlternateFunction<AF3, T>> where T:OutputMode, {}
+unsafe impl SdaPin<I2C0> for PB3<AlternateFunction<AF3, OpenDrain<Floating>>> {}
+
+unsafe impl<T> SclPin<I2C1> for PA6<AlternateFunction<AF3, T>> where T:OutputMode, {}
+unsafe impl SdaPin<I2C1> for PA7<AlternateFunction<AF3, OpenDrain<Floating>>> {}
+
+unsafe impl<T> SclPin<I2C2> for PE4<AlternateFunction<AF3, T>> where T:OutputMode, {}
+unsafe impl SdaPin<I2C2> for PE5<AlternateFunction<AF3, OpenDrain<Floating>>> {}
+
+unsafe impl<T> SclPin<I2C3> for PD0<AlternateFunction<AF3, T>> where T:OutputMode, {}
+unsafe impl SdaPin<I2C3> for PD1<AlternateFunction<AF3, OpenDrain<Floating>>> {}
+
+/// I2C peripheral operating in master mode
+pub struct I2c<I2C, PINS> {
+    i2c: I2C,
+    pins: PINS,
+}
+
+macro_rules! busy_wait {
+    ($i2c:expr, $flag:ident, $op:ident) => {
+        loop {
+            let mcs = $i2c.mcs.read();
+
+            if mcs.error().bit_is_set() {
+                if mcs.adrack().bit_is_set() {
+                    return Err(Error::AdrAck);
+                } else if mcs.datack().bit_is_set() {
+                    return Err(Error::DataAck);
+                }
+                return Err(Error::Bus);
+            } else if mcs.arblst().bit_is_set() {
+                return Err(Error::Arbitration);
+            } else if mcs.$flag().$op() {
+                break;
+            } else {
+                // try again
+            }
+        }
+    }
+}
+
+macro_rules! hal {
+    ($($I2CX:ident: ($powerDomain:ident, $i2cX:ident),)+) => {
+        $(
+            impl<SCL, SDA> I2c<$I2CX, (SCL, SDA)> {
+                /// Configures the I2C peripheral to work in master mode
+                pub fn $i2cX<F>(
+                    i2c: $I2CX,
+                    pins: (SCL, SDA),
+                    freq: F,
+                    clocks: &Clocks,
+                    pc: &sysctl::PowerControl,
+                ) -> Self where
+                    F: Into<Hertz>,
+                    SCL: SclPin<$I2CX>,
+                    SDA: SdaPin<$I2CX>,
+                {
+                    sysctl::control_power(
+                        pc, sysctl::Domain::$powerDomain,
+                        sysctl::RunMode::Run, sysctl::PowerState::On);
+                    sysctl::reset(pc, sysctl::Domain::$powerDomain);
+
+                    // set Master Function Enable, and clear other bits.
+                    i2c.mcr.write(|w| w.mfe().set_bit());
+
+                    // Write TimerPeriod configuration and clear other bits.
+                    let freq = freq.into().0;
+                    let tpr = ((clocks.sysclk.0/(2*10*freq))-1) as u8;
+
+                    i2c.mtpr.write(|w| unsafe {w.tpr().bits(tpr)});
+
+                    I2c { i2c, pins }
+                }
+
+                /// Releases the I2C peripheral and associated pins
+                pub fn free(self) -> ($I2CX, (SCL, SDA)) {
+                    (self.i2c, self.pins)
+                }
+            }
+
+            impl<PINS> Write for I2c<$I2CX, PINS> {
+                type Error = Error;
+
+                fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
+                    // Write Slave address and clear Receive bit
+                    self.i2c.msa.write(|w| unsafe {
+                        w.sa().bits(addr)
+                    });
+
+                    // Put first byte in data register
+                    self.i2c.mdr.write(|w| unsafe {
+                        w.data().bits(bytes[0])
+                    });
+
+                    let sz = bytes.len();
+
+                    busy_wait!(self.i2c, busbsy, bit_is_clear);
+
+                    // Send START + RUN
+                    // If single byte transfer, set STOP
+                    self.i2c.mcs.write(|w| {
+                        if sz == 1 {
+                            w.stop().set_bit();
+                        }
+                        w.start().set_bit()
+                            .run().set_bit()
+                    });
+
+                    for (i,byte) in (&bytes[1..]).iter().enumerate() {
+                        busy_wait!(self.i2c, busy, bit_is_clear);
+
+                        // Put next byte in data register
+                        self.i2c.mdr.write(|w| unsafe {
+                            w.data().bits(*byte)
+                        });
+
+                        // Send RUN command (Burst continue)
+                        // Set STOP on last byte
+                        self.i2c.mcs.write(|w| {
+                            if (i+1) == (sz-1) {
+                                w.stop().set_bit();
+                            }
+                            w.run().set_bit()
+                        });
+                    }
+
+                    busy_wait!(self.i2c, busy, bit_is_clear);
+
+                    Ok(())
+                }
+            }
+
+            impl<PINS> Read for I2c<$I2CX, PINS> {
+                type Error = Error;
+
+                fn read(
+                    &mut self,
+                    addr: u8,
+                    buffer: &mut [u8],
+                ) -> Result<(), Error> {
+
+                    // Write Slave address and set Receive bit
+                    self.i2c.msa.write(|w| unsafe {
+                        w.sa().bits(addr)
+                            .rs().set_bit()
+                    });
+
+                    busy_wait!(self.i2c, busbsy, bit_is_clear);
+                    let recv_sz = buffer.len();
+
+                    if recv_sz == 1 {
+                        // Single receive
+                        self.i2c.mcs.write(|w| {
+                            w.run().set_bit()
+                                .start().set_bit()
+                                .stop().set_bit()
+                        });
+
+                        busy_wait!(self.i2c, busy, bit_is_clear);
+                        buffer[0] = self.i2c.mdr.read().data().bits();
+                    } else {
+                        self.i2c.mcs.write(|w| {
+                            w.start().set_bit()
+                                .run().set_bit()
+                                .ack().set_bit()
+                        });
+
+                        busy_wait!(self.i2c, busy, bit_is_clear);
+                        buffer[0] = self.i2c.mdr.read().data().bits();
+
+                        for byte in &mut buffer[1..recv_sz-1] {
+                            self.i2c.mcs.write(|w| {
+                                w.run().set_bit()
+                                    .ack().set_bit()
+                            });
+                            busy_wait!(self.i2c, busy, bit_is_clear);
+                            *byte = self.i2c.mdr.read().data().bits();
+                        }
+                        self.i2c.mcs.write(|w| {
+                            w.run().set_bit()
+                                .stop().set_bit()
+                        });
+
+                        busy_wait!(self.i2c, busy, bit_is_clear);
+                        buffer[recv_sz-1] = self.i2c.mdr.read().data().bits();
+                    }
+
+                    Ok(())
+                }
+            }
+
+            impl<PINS> WriteRead for I2c<$I2CX, PINS> {
+                type Error = Error;
+
+                fn write_read(
+                    &mut self,
+                    addr: u8,
+                    bytes: &[u8],
+                    buffer: &mut [u8],
+                ) -> Result<(), Error> {
+
+                    let write_len = bytes.len();
+
+                    if buffer.len() == 0 {
+                       return self.write(addr, bytes);
+                    }
+
+                    if bytes.len() == 0 {
+                        return self.read(addr, buffer);
+                    }
+
+                    // Write Slave address and clear Receive bit
+                    self.i2c.msa.write(|w| unsafe {
+                        w.sa().bits(addr)
+                    });
+
+                    // send first byte
+                    self.i2c.mdr.write(|w| unsafe {
+                        w.data().bits(bytes[0])
+                    });
+
+                    busy_wait!(self.i2c, busbsy, bit_is_clear);
+
+                    self.i2c.mcs.write(|w| {
+                        w.start().set_bit()
+                            .run().set_bit()
+                    });
+
+                    busy_wait!(self.i2c, busy, bit_is_clear);
+
+                    for byte in (&bytes[1..write_len]).iter() {
+                        self.i2c.mdr.write(|w| unsafe {
+                            w.data().bits(*byte)
+                        });
+
+                        self.i2c.mcs.write(|w| {
+                            w.run().set_bit()
+                        });
+
+                        busy_wait!(self.i2c, busy, bit_is_clear);
+                    }
+
+                    // Write Slave address and set Receive bit
+                    self.i2c.msa.write(|w| unsafe {
+                        w.sa().bits(addr)
+                            .rs().set_bit()
+                    });
+
+                    let recv_sz = buffer.len();
+
+                    if recv_sz == 1 {
+                        // emit Repeated START and STOP for single receive
+                        self.i2c.mcs.write(|w| {
+                            w.run().set_bit()
+                                .start().set_bit()
+                                .stop().set_bit()
+                        });
+
+                        busy_wait!(self.i2c, busy, bit_is_clear);
+                        buffer[0] = self.i2c.mdr.read().data().bits();
+                    } else {
+                        // emit Repeated START
+                        self.i2c.mcs.write(|w| {
+                            w.run().set_bit()
+                                .start().set_bit()
+                                .ack().set_bit()
+                        });
+
+                        busy_wait!(self.i2c, busy, bit_is_clear);
+                        buffer[0] = self.i2c.mdr.read().data().bits();
+
+                        for byte in &mut buffer[1..recv_sz-1] {
+                            self.i2c.mcs.write(|w| {
+                                w.run().set_bit()
+                                    .ack().set_bit()
+                            });
+                            busy_wait!(self.i2c, busy, bit_is_clear);
+                            *byte = self.i2c.mdr.read().data().bits();
+                        }
+
+                        self.i2c.mcs.write(|w| {
+                            w.run().set_bit()
+                                .stop().set_bit()
+                        });
+
+                        busy_wait!(self.i2c, busy, bit_is_clear);
+                        buffer[recv_sz-1] = self.i2c.mdr.read().data().bits();
+                    }
+
+                    Ok(())
+                }
+            }
+        )+
+    }
+}
+
+hal! {
+    I2C0: (I2c0, i2c0),
+    I2C1: (I2c1, i2c1),
+    I2C2: (I2c2, i2c2),
+    I2C3: (I2c3, i2c3),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub extern crate tm4c123x;
 pub mod delay;
 pub mod gpio;
 pub mod prelude;
+pub mod i2c;
 pub mod serial;
 pub mod sysctl;
 pub mod time;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub mod delay;
 pub mod gpio;
 pub mod prelude;
 pub mod i2c;
+pub mod spi;
 pub mod serial;
 pub mod sysctl;
 pub mod time;

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,0 +1,189 @@
+//! Serial Peripheral Interface (SPI) bus
+
+use hal::spi::{FullDuplex, Mode , Phase, Polarity};
+use nb;
+use tm4c123x::{SSI0,SSI1, SSI2, SSI3};
+
+use gpio::gpioa::{PA2, PA4, PA5};
+use gpio::gpiob::{PB4, PB6, PB7};
+use gpio::gpiod::{PD0, PD2, PD3};
+
+use sysctl::Clocks;
+use sysctl;
+
+use gpio::{AF1, AF2, AlternateFunction, OutputMode};
+use time::Hertz;
+
+/// SPI error
+#[derive(Debug)]
+pub enum Error {
+    #[doc(hidden)] _Extensible,
+}
+
+// FIXME these should be "closed" traits
+/// SCK pin -- DO NOT IMPLEMENT THIS TRAIT
+pub unsafe trait SckPin<SPI> {}
+
+/// MISO pin -- DO NOT IMPLEMENT THIS TRAIT
+pub unsafe trait MisoPin<SPI> {}
+
+/// MOSI pin -- DO NOT IMPLEMENT THIS TRAIT
+pub unsafe trait MosiPin<SPI> {}
+
+// SSI0
+unsafe impl<T> SckPin<SSI0> for PA2<AlternateFunction<AF2, T>> where T:OutputMode, {}
+unsafe impl<T> MisoPin<SSI0> for PA4<AlternateFunction<AF2, T>> where T:OutputMode, {}
+unsafe impl<T> MosiPin<SSI0> for PA5<AlternateFunction<AF2, T>> where T:OutputMode, {}
+
+// SSI1
+unsafe impl<T> SckPin<SSI1> for PD0<AlternateFunction<AF2, T>> where T:OutputMode, {}
+unsafe impl<T> MisoPin<SSI1> for PD2<AlternateFunction<AF2, T>> where T:OutputMode, {}
+unsafe impl<T> MosiPin<SSI1> for PD3<AlternateFunction<AF2, T>> where T:OutputMode, {}
+
+// SSI2
+unsafe impl<T> SckPin<SSI2> for PB4<AlternateFunction<AF2, T>> where T:OutputMode, {}
+unsafe impl<T> MisoPin<SSI2> for PB6<AlternateFunction<AF2, T>> where T:OutputMode, {}
+unsafe impl<T> MosiPin<SSI2> for PB7<AlternateFunction<AF2, T>> where T:OutputMode, {}
+
+// SSI3
+unsafe impl<T> SckPin<SSI3> for PD0<AlternateFunction<AF1, T>> where T:OutputMode, {}
+unsafe impl<T> MisoPin<SSI3> for PD2<AlternateFunction<AF1, T>> where T:OutputMode, {}
+unsafe impl<T> MosiPin<SSI3> for PD3<AlternateFunction<AF1, T>> where T:OutputMode, {}
+
+/// SPI peripheral operating in full duplex master mode
+pub struct Spi<SPI, PINS> {
+    spi: SPI,
+    pins: PINS,
+}
+
+macro_rules! busy_wait {
+    ($spi:expr, $flag:ident, $op:ident) => {
+        loop {
+            let sr = $spi.sr.read();
+            if sr.$flag().$op() {
+                break;
+            }
+        }
+    }
+}
+
+macro_rules! hal {
+    ($($SPIX:ident: ($powerDomain:ident, $spiX:ident),)+) => {
+        $(
+            impl<SCK, MISO, MOSI> Spi<$SPIX, (SCK, MISO, MOSI)> {
+                /// Configures the SPI peripheral to operate in full duplex master mode
+                pub fn $spiX<F>(
+                    spi: $SPIX,
+                    pins: (SCK, MISO, MOSI),
+                    mode: Mode,
+                    freq: F,
+                    clocks: &Clocks,
+                    pc: &sysctl::PowerControl,
+                ) -> Self
+                where
+                    F: Into<Hertz>,
+                    SCK: SckPin<$SPIX>,
+                    MISO: MisoPin<$SPIX>,
+                    MOSI: MosiPin<$SPIX>,
+                {
+                    // power up
+                    sysctl::control_power(
+                        pc, sysctl::Domain::$powerDomain,
+                        sysctl::RunMode::Run, sysctl::PowerState::On);
+                    sysctl::reset(pc, sysctl::Domain::$powerDomain);
+
+                    // write 0 (reset value) for master operation.
+                    spi.cr1.write(|w| w);
+
+                    // SSICC Clock setup
+                    // set to reset value (0 = use system clock)
+                    spi.cc.write(|w| w);
+
+                    // Use Moto/SPI & 8bits data size
+                    let scr: u8;
+                    let mut cpsr = 2u32;
+                    let target_bitrate : u32 = clocks.sysclk.0 / freq.into().0;
+
+                    // Find solution for
+                    // SSInClk = SysClk / (CPSDVSR * (1 + SCR))
+                    // with:
+                    //   CPSDVSR in [2,254]
+                    //   SCR in [0,255]
+
+                    loop {
+                        let scr32 = (target_bitrate / cpsr) - 1;
+                        if scr32 < 255 {
+                            scr = scr32 as u8;
+                            break;
+                        }
+                        cpsr += 2;
+                        assert!(cpsr <= 254);
+                    }
+
+                    let cpsr = cpsr as u8;
+
+                    spi.cpsr.write(|w| unsafe {
+                        w.cpsdvsr().bits(cpsr)
+                    });
+
+                    spi.cr0.modify(|_,w| unsafe {
+                        w.spo().bit(mode.polarity == Polarity::IdleHigh)
+                            .sph().bit(mode.phase == Phase::CaptureOnSecondTransition)
+                            // FIXME: How to use FRFR::MOTO and DSS:: ?
+                            .frf().bits(0)
+                            .dss().bits(0x7)
+                            .scr().bits(scr)
+                    });
+
+                    // Enable peripheral
+                    spi.cr1.write(|w| w.sse().set_bit());
+
+                    Spi { spi, pins }
+                }
+
+                /// Releases the SPI peripheral and associated pins
+                pub fn free(self) -> ($SPIX, (SCK, MISO, MOSI)) {
+                    (self.spi, self.pins)
+                }
+            }
+
+            impl<PINS> FullDuplex<u8> for Spi<$SPIX, PINS> {
+                type Error = Error;
+
+                fn read(&mut self) -> nb::Result<u8, Error> {
+                    // Receive FIFO Not Empty
+                    if self.spi.sr.read().rne().bit_is_clear() {
+                        Err(nb::Error::WouldBlock)
+                    } else {
+                        let r = self.spi.dr.read().data().bits() as u8;
+                        Ok(r)
+                    }
+                }
+
+                fn send(&mut self, byte: u8) -> nb::Result<(), Error> {
+                    // Transmit FIFO Not Full
+                    if self.spi.sr.read().tnf().bit_is_clear() {
+                        Err(nb::Error::WouldBlock)
+                    } else {
+                        self.spi.dr.write(|w| unsafe {
+                            w.data().bits(byte.into())
+                        });
+                        busy_wait!(self.spi, bsy, bit_is_clear);
+                        Ok(())
+                    }
+                }
+            }
+
+            impl<PINS> ::hal::blocking::spi::transfer::Default<u8> for Spi<$SPIX, PINS> {}
+
+            impl<PINS> ::hal::blocking::spi::write::Default<u8> for Spi<$SPIX, PINS> {}
+        )+
+    }
+}
+
+hal! {
+    SSI0: (Ssi0, spi0),
+    SSI1: (Ssi1, spi1),
+    SSI2: (Ssi2, spi2),
+    SSI3: (Ssi3, spi3),
+}


### PR DESCRIPTION
This is an early (but working) support for both SPI and I2C.
I2C has been tested with a DS 3231 RTC + logical analyzer.
SPI has been tested with MAX7219 + logical analyzer.

Chances are that there are still some bugs, but  it's still better than no support at all :)

I'm still new to Rust, so there may be some construct that are not idiomatic... In particular, the types used for alternate function are still a bit new for me, so my solution may not be the best.