### PR TITLE
update dependencies and apply corresponding API changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ version = "0.2.2"
 default-features = false
 
 [dependencies.cortex-m]
-version = "0.5"
+version = "0.5.2"
 
 [dependencies.embedded-hal]
-version = "0.1.1"
+version = "0.2.1"
 features = ["unproven"]
 
 [dependencies.nb]

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -34,7 +34,7 @@
 
 use bb;
 use core::marker::PhantomData;
-use hal::digital::{InputPin, OutputPin};
+use hal::digital::{InputPin, OutputPin, StatefulOutputPin};
 use sysctl;
 
 /// Extension trait to split a GPIO peripheral in independent pins and registers
@@ -305,16 +305,18 @@ macro_rules! gpio {
                 _mode: PhantomData<MODE>,
             }
 
-            impl<MODE> OutputPin for $PXx<Output<MODE>> where MODE: OutputMode {
-                fn is_high(&self) -> bool {
+            impl<MODE> StatefulOutputPin for $PXx<Output<MODE>> where MODE: OutputMode {
+                fn is_set_high(&self) -> bool {
                     let p = unsafe { &*$GPIOX::ptr() };
                     bb::read_bit(&p.data, self.i)
                 }
 
-                fn is_low(&self) -> bool {
-                    !self.is_high()
+                fn is_set_low(&self) -> bool {
+                    !self.is_set_high()
                 }
+            }
 
+            impl<MODE> OutputPin for $PXx<Output<MODE>> where MODE: OutputMode {
                 fn set_high(&mut self) {
                     let p = unsafe { &*$GPIOX::ptr() };
                     unsafe { bb::change_bit(&p.data, self.i, true); }
@@ -566,16 +568,18 @@ macro_rules! gpio {
                     }
                 }
 
-                impl<MODE> OutputPin for $PXi<Output<MODE>> where MODE: OutputMode {
-                    fn is_high(&self) -> bool {
+                impl<MODE> StatefulOutputPin for $PXi<Output<MODE>> where MODE: OutputMode {
+                    fn is_set_high(&self) -> bool {
                         let p = unsafe { &*$GPIOX::ptr() };
                         bb::read_bit(&p.data, $i)
                     }
 
-                    fn is_low(&self) -> bool {
-                        !self.is_high()
+                    fn is_set_low(&self) -> bool {
+                        !self.is_set_high()
                     }
+                }
 
+                impl<MODE> OutputPin for $PXi<Output<MODE>> where MODE: OutputMode {
                     fn set_high(&mut self) {
                         let p = unsafe { &*$GPIOX::ptr() };
                         unsafe { bb::change_bit(&p.data, $i, true); }


### PR DESCRIPTION
Bump dependencies and change how output pin are handled.
OuputPin is only used for output-only. If the pin can also be read, it
should use the StatefulOutputPin trait.