### PR TITLE
Add example for MSP432E401Y Launchpad for Ethernet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
 	"tm4c-hal",
 	"examples/tiva-c-launchpad",
 	"examples/tiva-c-connected-launchpad",
+	"examples/msp432-launchpad-for-ethernet",
 ]
 
 [profile.release]

--- a/examples/msp432-launchpad-for-ethernet/.cargo/config
+++ b/examples/msp432-launchpad-for-ethernet/.cargo/config
@@ -1,0 +1,14 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+# uncomment ONE of these three option to make `cargo run` start a GDB session
+# which option to pick depends on your system
+# runner = "arm-none-eabi-gdb -q -x openocd.gdb"
+# runner = "gdb-multiarch -q -x openocd.gdb"
+# runner = "gdb -q -x openocd.gdb"
+runner = "probe-rs run --chip MSP432E411Y --protocol swd --speed 4000"
+
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]
+
+[build]
+target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)

--- a/examples/msp432-launchpad-for-ethernet/.gitignore
+++ b/examples/msp432-launchpad-for-ethernet/.gitignore
@@ -1,0 +1,5 @@
+**/*.rs.bk
+.#*
+.gdb_history
+Cargo.lock
+target/

--- a/examples/msp432-launchpad-for-ethernet/Cargo.toml
+++ b/examples/msp432-launchpad-for-ethernet/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+authors = [
+	"9names",
+]
+edition = "2018"
+readme = "README.md"
+name = "msp432-launchpad-for-ethernet"
+version = "0.1.0"
+
+[dependencies]
+cortex-m = "0.7"
+cortex-m-rt = "0.7"
+cortex-m-semihosting = "0.5"
+panic-halt = "0.2.0"
+
+# MSP432E401Y is functionally equivalent to TM4C1294NCPDT as used in Tiva C Connected Launchpad.
+# The only difference is MSP432 has SimpleLink functions in ROM
+# and TM4C has TivaWare functions in ROM.
+# As long as tm4c129x-hal never uses ROM functions these chips are, as far as I know, 100% compatible.
+# They certainly have the same memory map, appear to have the same periperals and share the same errata list.
+[dependencies.tm4c129x-hal]
+# version = "0.7.0"
+path = "../../tm4c129x-hal"
+features = ["rt"]
+
+# this lets you use `cargo fix`!
+[[bin]]
+name = "msp432-launchpad-for-ethernet"
+test = false
+bench = false

--- a/examples/msp432-launchpad-for-ethernet/Cargo.toml
+++ b/examples/msp432-launchpad-for-ethernet/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 readme = "README.md"
 name = "msp432-launchpad-for-ethernet"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 cortex-m = "0.7"

--- a/examples/msp432-launchpad-for-ethernet/README.md
+++ b/examples/msp432-launchpad-for-ethernet/README.md
@@ -1,0 +1,20 @@
+# MSP432 Launchpad for Ethernet Demo Application
+
+> For the MSP432 Launchpad developement kit for Ethernet SimpleLink MCU, [MSP-EXP432E401Y](https://www.ti.com/tool/MSP-EXP432E401Y)
+
+## License
+
+This template is licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.

--- a/examples/msp432-launchpad-for-ethernet/README.md
+++ b/examples/msp432-launchpad-for-ethernet/README.md
@@ -4,7 +4,7 @@
 
 ## License
 
-This template is licensed under either of
+This example is licensed under either of
 
 - Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
   http://www.apache.org/licenses/LICENSE-2.0)

--- a/examples/msp432-launchpad-for-ethernet/openocd.cfg
+++ b/examples/msp432-launchpad-for-ethernet/openocd.cfg
@@ -1,0 +1,4 @@
+# Sample OpenOCD configuration for the MSP432 Launchpad for Ethernet board
+
+source [find board/ti_msp432_launchpad.cfg]
+

--- a/examples/msp432-launchpad-for-ethernet/openocd.gdb
+++ b/examples/msp432-launchpad-for-ethernet/openocd.gdb
@@ -1,0 +1,32 @@
+target extended-remote :3333
+
+# print demangled symbols
+set print asm-demangle on
+
+# detect unhandled exceptions, hard faults and panics
+break DefaultHandler
+break UserHardFault
+break rust_begin_unwind
+
+# *try* to stop at the user entry point (it might be gone due to inlining)
+break main
+
+monitor arm semihosting enable
+
+# # send captured ITM to the file itm.fifo
+# # (the microcontroller SWO pin must be connected to the programmer SWO pin)
+# # 8000000 must match the core clock frequency
+# monitor tpiu config internal itm.txt uart off 8000000
+
+# # OR: make the microcontroller SWO pin output compatible with UART (8N1)
+# # 8000000 must match the core clock frequency
+# # 2000000 is the frequency of the SWO pin
+# monitor tpiu config external uart off 8000000 2000000
+
+# # enable ITM port 0
+# monitor itm port 0 on
+
+load
+
+# start the process but immediately halt the processor
+stepi

--- a/examples/msp432-launchpad-for-ethernet/src/main.rs
+++ b/examples/msp432-launchpad-for-ethernet/src/main.rs
@@ -1,0 +1,80 @@
+#![no_std]
+#![no_main]
+
+use panic_halt as _; // you can put a breakpoint on `rust_begin_unwind` to catch panics
+
+use core::fmt::Write;
+use cortex_m_rt::entry;
+use tm4c129x_hal::{self as hal, prelude::*};
+
+#[entry]
+fn main() -> ! {
+    let cp = hal::CorePeripherals::take().unwrap();
+    let p = hal::Peripherals::take().unwrap();
+
+    let mut sc = p.SYSCTL.constrain();
+    sc.clock_setup.oscillator = hal::sysctl::Oscillator::Main(
+        hal::sysctl::CrystalFrequency::_25mhz,
+        hal::sysctl::SystemClock::UsePll(hal::sysctl::PllOutputFrequency::_120mhz),
+    );
+    let clocks = sc.clock_setup.freeze();
+
+    let mut porta = p.GPIO_PORTA_AHB.split(&sc.power_control);
+    let portn = p.GPIO_PORTN.split(&sc.power_control);
+    let portf = p.GPIO_PORTF_AHB.split(&sc.power_control);
+
+    // Activate UART
+    let mut uart = hal::serial::Serial::uart0(
+        p.UART0,
+        porta
+            .pa1
+            .into_af_push_pull::<hal::gpio::AF1>(&mut porta.control),
+        porta
+            .pa0
+            .into_af_push_pull::<hal::gpio::AF1>(&mut porta.control),
+        (),
+        (),
+        115200_u32.bps(),
+        hal::serial::NewlineMode::SwapLFtoCRLF,
+        &clocks,
+        &sc.power_control,
+    );
+    let mut led1 = portn.pn1.into_push_pull_output();
+    let mut led2 = portn.pn0.into_push_pull_output();
+    let mut led3 = portf.pf4.into_push_pull_output();
+    let mut led4 = portf.pf0.into_push_pull_output();
+
+    let mut counter = 0u32;
+    let mut delay = cortex_m::delay::Delay::new(cp.SYST, 120_000_000u32);
+    loop {
+        writeln!(uart, "Hello, world! counter={}", counter).unwrap();
+        let led_state = counter % 4;
+        if led_state == 0 {
+            led1.set_high();
+            led2.set_low();
+            led3.set_low();
+            led4.set_low();
+        }
+        if led_state == 1 {
+            led1.set_low();
+            led2.set_high();
+            led3.set_low();
+            led4.set_low();
+        }
+        if led_state == 2 {
+            led1.set_low();
+            led2.set_low();
+            led3.set_high();
+            led4.set_low();
+        }
+        if led_state == 3 {
+            led1.set_low();
+            led2.set_low();
+            led3.set_low();
+            led4.set_high();
+        }
+
+        counter = counter.wrapping_add(1);
+        delay.delay_ms(200);
+    }
+}


### PR DESCRIPTION
MSP432E401Y is (as far as I know) just TM4C1294NCPD with different functions in ROM.
Since this HAL does not use the SimpleLink ROM functions, this chip should be 100% compatible with [tm4c129x-hal](https://github.com/rust-embedded-community/tm4c-hal/tree/master/tm4c129x-hal)

I've tested it out UART and GPIO on the launchpad. Everything is working fine so far.
Wasn't sure if you'd accept something like this in your HAL - I'm happy to keep this example project as a separate thing on my github account, but I figured it was worth making a PR just in case.

Note that the default runner is `probe-rs run`, which does not support this chip until https://github.com/probe-rs/probe-rs/pull/1139 is merged.